### PR TITLE
Use new resources directory structure for sw_extends

### DIFF
--- a/src/Resources/views/storefront/layout/header/logo.html.twig
+++ b/src/Resources/views/storefront/layout/header/logo.html.twig
@@ -1,4 +1,4 @@
-{% sw_extends '@Storefront/layout/header/logo.html.twig' %}
+{% sw_extends '@Storefront/storefront/layout/header/logo.html.twig' %}
 
 {% block layout_header_logo_link %}
     <h2>Hello world!</h2>


### PR DESCRIPTION
The entry points for administration and storefront resources changed (again). 

See: https://github.com/shopware/platform/blob/f140c6761e5a6dec1a9ed1b50ba47691e22d0991/src/Docs/Resources/platform-updates/2019-11-14-refactored-directory-structure.md